### PR TITLE
SIV-565: CONSUMER - Fix Security Vulnerabilities

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,8 @@
   <description>Kafka consumer for authcode-changed events.</description>
   <properties>
     <java.version>21</java.version>
-    <spring-boot.version>3.5.0</spring-boot.version>
+    <spring-boot.version>3.5.4</spring-boot.version>
+    <springframework.version>6.2.10</springframework.version>
     <maven.compiler.release>${java.version}</maven.compiler.release>
     <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
     <maven-surefire-plugin.version>3.5.1</maven-surefire-plugin.version>
@@ -35,7 +36,7 @@
     <kafka-models.version>3.0.21</kafka-models.version>
 
     <logback-classic.version>1.5.16</logback-classic.version>
-    <tomcat-core-and-websocket.version>11.0.9</tomcat-core-and-websocket.version>
+    <tomcat-core-and-websocket.version>11.0.10</tomcat-core-and-websocket.version>
     <grpc.version>1.73.0</grpc.version>
 
     <sonar-maven-plugin.version>4.0.0.4121</sonar-maven-plugin.version>
@@ -79,7 +80,12 @@
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-web</artifactId>
-      <version>6.2.8</version>
+      <version>${springframework.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-core</artifactId>
+      <version>${springframework.version}</version>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
## JIRA Ticket Number / Name

[SIV-656: CONSUMER - Fix Security Vulnerabilities](https://companieshouse.atlassian.net/browse/SIV-656)

## Short description outlining key changes/additions

Fixed vulnerabilities:
| CVE ID        | Library                         | Update Version |
|---------------|---------------------------------|----------------|
| CVE-2025-41242 | spring-core-6.2.7.jar           | 6.2.10         |
| CVE-2025-48989 | tomcat-embed-core-11.0.9.jar    | 11.0.10        |


### Type of change

* [x] Bug fix
* [ ] New feature
* [ ] Breaking change
* [ ] Infrastructure change
* [ ] Tech Debt

### Pull request checklist

* [ ] I have added unit tests for new code that I have added
* [ ] I have added/updated functional tests where appropriate
* [ ] The code follows our [coding standards](https://github.com/companieshouse/styleguides/blob/master/java.md)

**An exhaustive list of peer review checks can be read [here](https://github.com/companieshouse/styleguides/blob/master/java_review.md#developer-actions-prior-to-code-commitreview-started)**

## Addition notes 

Ideally, the Spring Boot dependency management would already provide the latest spring-core without vulnerabilities. However, the current release (Spring Boot 3.5.4) manages Spring Framework 6.2.9, not 6.2.10.

This will be resolved in Spring Boot 3.5.5, which is expected shortly. Once that is available, we should remove the explicit spring-core override and instead update spring-boot.version to 3.5.5.

https://spring.io/blog/2025/08/14/spring-framework-6-2-10-release-fixes-cve-2025-41242