### PR TITLE
ASM-1076: Spring Boot 4 upgrade and CVE fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
     <!-- Transitive CVE pins -->
     <jetty-bom.version>12.0.35</jetty-bom.version>
     <plexus-utils.version>4.0.3</plexus-utils.version>
-    <msgpack-core.version>0.9.10</msgpack-core.version>
+    <msgpack-core.version>0.9.12</msgpack-core.version>
     <avro.version>1.12.1</avro.version>
     <lz4-java-fork.version>1.10.2</lz4-java-fork.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -16,8 +16,7 @@
   <description>Kafka consumer for authcode-changed events.</description>
   <properties>
     <java.version>21</java.version>
-    <spring-boot.version>3.5.4</spring-boot.version>
-    <springframework.version>6.2.10</springframework.version>
+    <spring-boot.version>4.0.6</spring-boot.version>
     <maven.compiler.release>${java.version}</maven.compiler.release>
     <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
     <maven-surefire-plugin.version>3.5.1</maven-surefire-plugin.version>
@@ -36,12 +35,18 @@
     <api-helper-java.version>3.0.1</api-helper-java.version>
     <kafka-models.version>3.0.21</kafka-models.version>
     <commons-beanutils.version>1.11.0</commons-beanutils.version>
-    <jakarta-annotation-api.version>1.3.5</jakarta-annotation-api.version>
     <jib-maven-plugin.version>3.4.0</jib-maven-plugin.version>
 
     <logback-classic.version>1.5.16</logback-classic.version>
-    <tomcat-core-and-websocket.version>11.0.10</tomcat-core-and-websocket.version>
+    <tomcat-core-and-websocket.version>11.0.22</tomcat-core-and-websocket.version>
     <grpc.version>1.73.0</grpc.version>
+
+    <!-- Transitive CVE pins -->
+    <jetty-bom.version>12.0.35</jetty-bom.version>
+    <plexus-utils.version>4.0.3</plexus-utils.version>
+    <msgpack-core.version>0.9.10</msgpack-core.version>
+    <avro.version>1.12.1</avro.version>
+    <lz4-java-fork.version>1.10.2</lz4-java-fork.version>
 
     <sonar-maven-plugin.version>4.0.0.4121</sonar-maven-plugin.version>
     <sonar.token>${CODE_ANALYSIS_TOKEN}</sonar.token>
@@ -53,6 +58,19 @@
   </properties>
   <dependencyManagement>
     <dependencies>
+      <!--
+        BOM overrides imported before spring-boot-dependencies so first-wins
+        BOM resolution forces every jetty artifact to a CVE-free version
+        instead of pinning each one by hand.
+       -->
+      <!-- CVE-2026-2332 (Critical), CVE-2026-1605, GHSA-xxh7-fcf3-rj7f, GHSA-355h-qmc2-wpwf -->
+      <dependency>
+        <groupId>org.eclipse.jetty.ee10</groupId>
+        <artifactId>jetty-ee10-bom</artifactId>
+        <version>${jetty-bom.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
       <dependency>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-dependencies</artifactId>
@@ -60,15 +78,27 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
+      <!-- Test/build-scope only: pulled in transitively by sonar-maven-plugin -->
+      <!-- CVE-2025-67030, GHSA-6fmv-xxpf-w3cw -->
+      <dependency>
+        <groupId>org.codehaus.plexus</groupId>
+        <artifactId>plexus-utils</artifactId>
+        <version>${plexus-utils.version}</version>
+      </dependency>
+      <!-- CVE-2026-21452, GHSA-cw39-r4h6-8j3x -->
+      <dependency>
+        <groupId>org.msgpack</groupId>
+        <artifactId>msgpack-core</artifactId>
+        <version>${msgpack-core.version}</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
   <dependencies>
-    <!-- Overrides -->
-    <!-- CVE-2025-41242 -->
+    <!-- Transitive override: kafka-models pulls in older avro - CVE-2025-33042 -->
     <dependency>
-      <groupId>org.springframework</groupId>
-      <artifactId>spring-core</artifactId>
-      <version>${springframework.version}</version>
+      <groupId>org.apache.avro</groupId>
+      <artifactId>avro</artifactId>
+      <version>${avro.version}</version>
     </dependency>
 
     <dependency>
@@ -219,7 +249,6 @@
     <dependency>
       <groupId>jakarta.annotation</groupId>
       <artifactId>jakarta.annotation-api</artifactId>
-      <version>${jakarta-annotation-api.version}</version>
     </dependency>
     <dependency>
       <groupId>io.grpc</groupId>
@@ -260,6 +289,20 @@
     <dependency>
       <groupId>org.springframework.kafka</groupId>
       <artifactId>spring-kafka</artifactId>
+      <exclusions>
+        <!-- org.lz4:lz4-java 1.8.0 is abandoned upstream; replaced below with maintained fork.
+             CVE-2025-12183, CVE-2025-66566, GHSA-cmp6-m4wj-q63q, GHSA-vqf4-7m7x-wgfc -->
+        <exclusion>
+          <groupId>org.lz4</groupId>
+          <artifactId>lz4-java</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <!-- Drop-in API-compatible community fork of the abandoned org.lz4:lz4-java -->
+    <dependency>
+      <groupId>at.yawk.lz4</groupId>
+      <artifactId>lz4-java</artifactId>
+      <version>${lz4-java-fork.version}</version>
     </dependency>
   </dependencies>
 

--- a/src/main/java/uk/gov/companieshouse/authcode/changed/service/KafkaConsumerService.java
+++ b/src/main/java/uk/gov/companieshouse/authcode/changed/service/KafkaConsumerService.java
@@ -8,6 +8,7 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.function.Supplier;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.kafka.annotation.BackOff;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.kafka.annotation.RetryableTopic;
 import org.springframework.kafka.retrytopic.DltStrategy;
@@ -15,7 +16,6 @@ import org.springframework.kafka.retrytopic.RetryTopicHeaders;
 import org.springframework.kafka.retrytopic.SameIntervalTopicReuseStrategy;
 import org.springframework.kafka.support.Acknowledgment;
 import org.springframework.messaging.handler.annotation.Header;
-import org.springframework.retry.annotation.Backoff;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -41,7 +41,7 @@ public class KafkaConsumerService {
             autoCreateTopics = "false",
             sameIntervalTopicReuseStrategy = SameIntervalTopicReuseStrategy.SINGLE_TOPIC,
             attempts = "${kafka.max-attempts}",
-            backoff = @Backoff(delayExpression = "${kafka.backoff-delay}"),
+            backOff = @BackOff(delayString = "${kafka.backoff-delay}"),
             exclude = NonRetryableErrorException.class,
             kafkaTemplate = "kafkaAuthCodeCancellationTemplate",
             dltTopicSuffix = "-error",

--- a/src/main/java/uk/gov/companieshouse/authcode/changed/utils/StaticPropertyUtil.java
+++ b/src/main/java/uk/gov/companieshouse/authcode/changed/utils/StaticPropertyUtil.java
@@ -1,6 +1,6 @@
 package uk.gov.companieshouse.authcode.changed.utils;
 
-import javax.annotation.PostConstruct;
+import jakarta.annotation.PostConstruct;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 


### PR DESCRIPTION
## JIRA Ticket Number / Name

[ASM-1076: Spring Boot 4 upgrade and CVE fixes](https://companieshouse.atlassian.net/browse/ASM-1076)

## Short description outlining key changes/additions

Upgrades to **Spring Boot 4.0.6** (Spring Framework 7, Tomcat 11.0.22, Spring Kafka 4) and resolves the May 2026 CVE batch raised against this service on Dependency Track. Mirrors the same upgrade applied to the sibling [`acsp-profile-delta-consumer` PR #20](https://github.com/companieshouse/acsp-profile-delta-consumer/pull/20).

### Spring Boot 4 migration

| Change | Why |
| --- | --- |
| `spring-boot.version`: `3.5.4` → `4.0.6` | Ticket scope. Brings Spring Framework 7, Tomcat 11.0.22, Spring Kafka 4. |
| Drop explicit `spring-core` override and `springframework.version` property | The override was there for CVE-2025-41242; Boot 4 BOM now ships Spring 7 which is past that fix. |
| `tomcat-core-and-websocket.version`: `11.0.10` → `11.0.22` | Clears all 9 tomcat findings. |
| Drop `jakarta-annotation-api` 1.3.5 pin | That release still ships the `javax.*` package and is incompatible with the `jakarta.annotation` imports Spring 7 requires. Boot 4 BOM manages a compatible version. |
| `@RetryableTopic.backoff = @Backoff(...)` → `backOff = @BackOff(...)` in `KafkaConsumerService` | Spring Kafka 4 dropped the transitive dependency on `spring-retry` and replaced the attribute with its own `org.springframework.kafka.annotation.BackOff`. `delayExpression` became `delayString` (placeholders still resolved). Behaviour unchanged. |
| `javax.annotation.PostConstruct` → `jakarta.annotation.PostConstruct` in `StaticPropertyUtil` | Final `javax.*` import in the service. |

### CVE fixes

**Resolved by the Spring Boot 4.0.6 BOM** (most of the Critical/High batch):

| Artifact | CVEs / GHSAs |
| --- | --- |
| `tomcat-embed-core` | CVE-2025-66614, GHSA-95jq-rwvf-vjx4, CVE-2025-55752, CVE-2026-24734, GHSA-mgp5-rv84-w37q, GHSA-rv64-5gf8-9qq8, GHSA-x4m4-345f-5h5g, GHSA-wmwf-9ccg-fff5 |
| `spring-boot-actuator-autoconfigure` | CVE-2026-40976, CVE-2026-22731, CVE-2026-22733 |
| `spring-boot-autoconfigure` | CVE-2026-40971, CVE-2026-40974 |
| `spring-boot` | CVE-2026-40975, CVE-2026-40973, GHSA-wwpq-f5c3-7hvx |
| `spring-boot-starter-actuator` | GHSA-mgvc-8q2h-5pgc, GHSA-8hfc-fq58-r658 |
| `spring-core` | CVE-2025-41249, GHSA-jmp9-x22r-554x |
| `kafka-clients` | CVE-2026-35554, GHSA-5qcv-4rpc-jp93 |
| `assertj-core` | CVE-2026-24400, GHSA-rqfh-9r24-8c9r |

**BOM override** imported ahead of `spring-boot-dependencies` so first-wins resolution pins every jetty artifact:

| BOM | Version | CVEs / GHSAs cleared |
| --- | --- | --- |
| `org.eclipse.jetty.ee10:jetty-ee10-bom` | `12.0.35` | CVE-2026-2332 (Critical), CVE-2026-1605, GHSA-xxh7-fcf3-rj7f, GHSA-355h-qmc2-wpwf across `jetty-http` / `jetty-server` |

**Direct transitive pins:**

| Artifact | Version | CVEs / GHSAs | Why pinned |
| --- | --- | --- | --- |
| `org.apache.avro:avro` | `1.12.1` | CVE-2025-33042 | Pulled in transitively by `kafka-models`. |
| `org.codehaus.plexus:plexus-utils` | `4.0.3` | CVE-2025-67030, GHSA-6fmv-xxpf-w3cw | Test/build scope only — transitive via `sonar-maven-plugin`. `<dependencyManagement>` override. |
| `org.msgpack:msgpack-core` | `0.9.12` | CVE-2026-21452, GHSA-cw39-r4h6-8j3x | Test/build scope only — transitive via `sonar-maven-plugin`. Fix landed in 0.9.11. |

**lz4-java (replaced):**

`org.lz4:lz4-java` 1.8.0 is abandoned upstream (last release Feb 2022, four open CVEs). Excluded from `spring-kafka` and replaced with the maintained, drop-in API-compatible community fork `at.yawk.lz4:lz4-java:1.10.2`. Same swap applied in [`auth-code-notification` PR #96](https://github.com/companieshouse/auth-code-notification/pull/96). Clears CVE-2025-12183, CVE-2025-66566, GHSA-cmp6-m4wj-q63q, GHSA-vqf4-7m7x-wgfc.

### Type of change

* [ ] Bug fix
* [ ] New feature
* [ ] Breaking change
* [x] Infrastructure change
* [x] Tech Debt

### Pull request checklist

* [x] I have added unit tests for new code that I have added — N/A, no behavioural source changes (only the `@RetryableTopic` attribute rename and a `javax`→`jakarta` import). All 20 existing tests still green under Spring Boot 4.
* [x] I have added/updated functional tests where appropriate — N/A.
* [x] The code follows our [coding standards](https://github.com/companieshouse/styleguides/blob/master/java.md)

## Notes to the tester

- `mvn clean verify` is green (20 unit tests pass) on Spring Boot 4.0.6 / Spring Kafka 4.
- OWASP `dependency-check` passes locally after the msgpack 0.9.12 bump.
- `mvn dependency:tree` confirms: `tomcat-embed-core:11.0.22`, `spring-boot:4.0.6`, `spring-kafka:4.x`, `kafka-clients:4.x`, `avro:1.12.1`, `plexus-utils:4.0.3`, `msgpack-core:0.9.12`, `at.yawk.lz4:lz4-java:1.10.2` present and `org.lz4:lz4-java` absent.